### PR TITLE
Implement Native AWS Authentication and API Requirements

### DIFF
--- a/API_SPECIFICATION.md
+++ b/API_SPECIFICATION.md
@@ -1,0 +1,149 @@
+# Kinetic Atelier - API Specification
+
+## 1. Authentication
+All API requests must be authenticated using **AWS IAM Authorization (SigV4)**.
+Clients must obtain temporary credentials from the Cognito Identity Pool after successful authentication with the Cognito User Pool (or via Social Identity Providers like Google).
+
+### Headers
+- `Authorization`: `AWS4-HMAC-SHA256 ...` (Standard SigV4 header)
+- `X-Amz-Date`: `<ISO8601-Timestamp>`
+- `X-Amz-Security-Token`: `<Session-Token>` (If using temporary credentials)
+
+---
+
+## 2. Endpoints
+
+### A. Profile
+#### `GET /profile`
+Fetches the user's profile and goals.
+- **Authorization**: IAM (Authenticated)
+- **Response (200 OK)**:
+  ```json
+  {
+    "userId": "string",
+    "name": "string",
+    "goals": {
+      "weight": number,
+      "dailyCalories": number,
+      "macros": { "p": number, "c": number, "f": number }
+    },
+    "isPro": boolean
+  }
+  ```
+
+---
+
+### B. Workouts
+#### `GET /workouts?userId={userId}`
+Fetches the workout history for a user.
+- **Authorization**: IAM (Authenticated)
+- **Response (200 OK)**:
+  ```json
+  [
+    {
+      "PK": "USER#<userId>",
+      "SK": "WORKOUT#<timestamp>",
+      "data": {
+        "id": "string",
+        "date": "string",
+        "title": "string",
+        "type": "string",
+        "duration": number,
+        "volume": number,
+        "exercises": [...]
+      }
+    }
+  ]
+  ```
+
+#### `POST /workouts`
+Logs a new workout.
+- **Authorization**: IAM (Authenticated)
+- **Request Body**:
+  ```json
+  {
+    "id": "string",
+    "date": "string",
+    "title": "string",
+    "type": "string",
+    "duration": number,
+    "volume": number,
+    "exercises": [...]
+  }
+  ```
+- **Response (200 OK)**: `{"status": "Workout event published"}`
+
+---
+
+### C. Vitals
+#### `GET /vitals?userId={userId}`
+Fetches the vitals history (weight, body fat).
+- **Authorization**: IAM (Authenticated)
+- **Response (200 OK)**:
+  ```json
+  [
+    {
+      "PK": "USER#<userId>",
+      "SK": "VITAL#<timestamp>",
+      "data": {
+        "date": "string",
+        "weight": number,
+        "bodyFat": number
+      }
+    }
+  ]
+  ```
+
+#### `POST /vitals`
+Logs daily vitals.
+- **Authorization**: IAM (Authenticated)
+- **Request Body**:
+  ```json
+  {
+    "date": "string",
+    "weight": number,
+    "bodyFat": number
+  }
+  ```
+- **Response (200 OK)**: `{"status": "Vitals event published"}`
+
+---
+
+### D. Routines
+#### `GET /routines?userId={userId}`
+Fetches saved workout routines.
+- **Authorization**: IAM (Authenticated)
+- **Response (200 OK)**:
+  ```json
+  [
+    {
+      "PK": "USER#<userId>",
+      "SK": "ROUTINE#<routineId>",
+      "data": {
+        "id": "string",
+        "name": "string",
+        "type": "string",
+        "target": "string",
+        "duration": number,
+        "exercises": ["string"]
+      }
+    }
+  ]
+  ```
+
+#### `POST /routines`
+Saves a new routine.
+- **Authorization**: IAM (Authenticated)
+- **Request Body**:
+  ```json
+  {
+    "userId": "string",
+    "routineId": "string",
+    "name": "string",
+    "type": "string",
+    "target": "string",
+    "duration": number,
+    "exercises": ["string"]
+  }
+  ```
+- **Response (200 OK)**: `{"status": "Routine saved"}`

--- a/MOBILE_SPECIFICATION.md
+++ b/MOBILE_SPECIFICATION.md
@@ -17,7 +17,14 @@ The Kinetic Atelier mobile application is a native SwiftUI companion to the web 
   - View weight trends over configurable timeframes (7 days, 30 days, 90 days, All time).
   - Calculate velocity and delta relative to user-defined goals.
 
-### 2.2 Feature Parity with Web Platform
+### 2.2 Native Authentication & API
+- **Cognito & IAM**:
+  - Secure login using AWS Cognito User Pool and Identity Pool.
+  - Multi-factor authentication support including biometric (Passkeys/FaceID/TouchID).
+  - Google Social Login integration.
+- **Signed API Requests**: All communication with the backend is performed using IAM-authorized REST calls (SigV4).
+
+### 2.3 Feature Parity with Web Platform
 - **Dashboard**: High-level summary of active days, calories burned, and current progress.
 - **Exercise Log**:
   - Log new workouts (Strength, HIIT, etc.).
@@ -98,3 +105,20 @@ The Kinetic Atelier mobile application is a native SwiftUI companion to the web 
   - **Unit Tests**: Execute `xcodebuild test` for the iOS target using a destination simulator (e.g., iPhone 15).
   - **Build Verification**: Ensure the app compiles for both iOS and Simulator architectures.
   - **Artifacts**: Upload test results and build logs for failure diagnosis.
+
+## 6. Authentication Architecture (SwiftUI)
+
+### 6.1 AuthService (MVVM)
+- **Role**: Centralized service for managing user sessions and authentication flows.
+- **Implementation**:
+  - Integrate with **AWS Mobile SDK for iOS** (Amplify or low-level Cognito/IAM SDKs).
+  - **Methods**:
+    - `signInWithEmail(email:password:)`: SRP-based authentication.
+    - `signInWithGoogle()`: OAuth2 flow using `ASWebAuthenticationSession`.
+    - `registerPasskey()`: WebAuthn registration via `AuthenticationServices` framework.
+    - `signInWithPasskey()`: Biometric authentication via `ASAuthorizationPlatformPublicKeyCredentialProvider`.
+  - **Session Management**: Store temporary IAM credentials and handle background token refreshing.
+
+### 6.2 SigV4 Interceptor
+- **Role**: Automatically sign all outgoing REST API requests with AWS Signature Version 4.
+- **Implementation**: Custom `URLSession` or middleware to inject `Authorization`, `X-Amz-Date`, and `X-Amz-Security-Token` headers.

--- a/cloud-requirements.md
+++ b/cloud-requirements.md
@@ -42,11 +42,21 @@ This document outlines the infrastructure and functional requirements for hostin
 ### E. Static Hosting
 - **AWS S3 + CloudFront**: For hosting the compiled Vite application assets.
 
+### F. Authentication (Native AWS Auth)
+- **Cognito User Pool**: Identity provider for user registration and sign-in.
+  - **Attributes**: Email is the primary sign-in attribute.
+  - **Social Auth**: Support for Google as a Social Identity Provider.
+  - **Passwordless/Biometrics**: Enable WebAuthn/Passkey support for seamless authentication.
+- **Cognito Identity Pool**: Provides temporary AWS credentials for authenticated users.
+  - **Role-Based Access**: Authenticated users are granted IAM permissions to invoke the API Gateway.
+- **IAM Authorization**: API Gateway methods are protected using `AWS_IAM` authorization. Clients must sign requests using SigV4.
+
 ## 3. Functional Requirements
 
 ### User & Profile Management
 - **Action**: Fetch user profile and goals.
-- **Implementation**: API Gateway GET -> DynamoDB GetItem.
+- **Implementation**: API Gateway GET `/profile` -> DynamoDB GetItem.
+- **PK/SK**: `PK: USER#<identityId>`, `SK: PROFILE#<identityId>`.
 - **Requirement**: Return current weight, goals, and "Pro" status.
 
 ### Workout Logging

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -3,7 +3,10 @@ import * as cdk from 'aws-cdk-lib/core';
 import { InfraStack } from '../lib/infra-stack';
 
 const app = new cdk.App();
-new InfraStack(app, 'InfraStack', {
+
+const envName = app.node.tryGetContext('env') || 'dev';
+
+new InfraStack(app, `KineticAtelierStack-${envName}`, {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -17,6 +17,9 @@ export class InfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    const envName = this.node.tryGetContext('env') || 'dev';
+    const isProd = envName === 'prod';
+
     // 1. Implement Cognito User Pool
     const userPool = new cognito.UserPool(this, 'KineticAtelierUserPool', {
       userPoolName: 'KineticAtelierUserPool',
@@ -33,7 +36,17 @@ export class InfraStack extends cdk.Stack {
         requireDigits: true,
         requireSymbols: true,
       },
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
+    // Google Identity Provider (Placeholder)
+    const googleIdP = new cognito.UserPoolIdentityProviderGoogle(this, 'GoogleIdP', {
+      userPool: userPool,
+      clientId: 'GOOGLE_CLIENT_ID', // Placeholder
+      clientSecret: 'GOOGLE_CLIENT_SECRET', // Placeholder
+      attributeMapping: {
+        email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+      },
     });
 
     const userPoolClient = new cognito.UserPoolClient(this, 'KineticAtelierUserPoolClient', {
@@ -43,8 +56,12 @@ export class InfraStack extends cdk.Stack {
           authorizationCodeGrant: true,
         },
         scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
-        callbackUrls: ['http://localhost:5173', 'kinetic-atelier://callback'],
-        logoutUrls: ['http://localhost:5173', 'kinetic-atelier://logout'],
+        callbackUrls: isProd
+          ? ['https://kinetic-atelier.app/callback', 'kinetic-atelier://callback']
+          : ['http://localhost:5173/callback', 'kinetic-atelier://callback'],
+        logoutUrls: isProd
+          ? ['https://kinetic-atelier.app/logout', 'kinetic-atelier://logout']
+          : ['http://localhost:5173/logout', 'kinetic-atelier://logout'],
       },
       supportedIdentityProviders: [
         cognito.UserPoolClientIdentityProvider.COGNITO,
@@ -55,14 +72,16 @@ export class InfraStack extends cdk.Stack {
         custom: true, // For WebAuthn/Passkey
       },
     });
+    userPoolClient.node.addDependency(googleIdP);
 
     // 2. Implement DynamoDB Table (KineticAtelierTable)
+
     const table = new dynamodb.Table(this, 'KineticAtelierTable', {
-      tableName: 'KineticAtelierTable',
+      tableName: `KineticAtelierTable-${envName}`,
       partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.DESTROY, // For dev purposes
+      removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
 
     // 3. Implement EventBridge Custom Event Bus

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -11,10 +11,50 @@ import * as path from 'path';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
 
 export class InfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+
+    // 1. Implement Cognito User Pool
+    const userPool = new cognito.UserPool(this, 'KineticAtelierUserPool', {
+      userPoolName: 'KineticAtelierUserPool',
+      selfSignUpEnabled: true,
+      signInAliases: { email: true },
+      autoVerify: { email: true },
+      standardAttributes: {
+        email: { required: true, mutable: true },
+      },
+      passwordPolicy: {
+        minLength: 8,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true,
+      },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const userPoolClient = new cognito.UserPoolClient(this, 'KineticAtelierUserPoolClient', {
+      userPool: userPool,
+      oAuth: {
+        flows: {
+          authorizationCodeGrant: true,
+        },
+        scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
+        callbackUrls: ['http://localhost:5173', 'kinetic-atelier://callback'],
+        logoutUrls: ['http://localhost:5173', 'kinetic-atelier://logout'],
+      },
+      supportedIdentityProviders: [
+        cognito.UserPoolClientIdentityProvider.COGNITO,
+        cognito.UserPoolClientIdentityProvider.GOOGLE,
+      ],
+      authFlows: {
+        userSrp: true,
+        custom: true, // For WebAuthn/Passkey
+      },
+    });
 
     // 2. Implement DynamoDB Table (KineticAtelierTable)
     const table = new dynamodb.Table(this, 'KineticAtelierTable', {
@@ -30,6 +70,39 @@ export class InfraStack extends cdk.Stack {
       eventBusName: 'KineticAtelierEventBus'
     });
 
+    // Cognito Identity Pool for IAM Auth
+    const identityPool = new cognito.CfnIdentityPool(this, 'KineticAtelierIdentityPool', {
+      allowUnauthenticatedIdentities: false,
+      cognitoIdentityProviders: [
+        {
+          clientId: userPoolClient.userPoolClientId,
+          providerName: userPool.userPoolProviderName,
+        },
+      ],
+    });
+
+    const authenticatedRole = new iam.Role(this, 'CognitoDefaultAuthenticatedRole', {
+      assumedBy: new iam.FederatedPrincipal(
+        'cognito-identity.amazonaws.com',
+        {
+          StringEquals: {
+            'cognito-identity.amazonaws.com:aud': identityPool.ref,
+          },
+          'ForAnyValue:StringLike': {
+            'cognito-identity.amazonaws.com:amr': 'authenticated',
+          },
+        },
+        'sts:AssumeRoleWithWebIdentity'
+      ),
+    });
+
+    new cognito.CfnIdentityPoolRoleAttachment(this, 'IdentityPoolRoleAttachment', {
+      identityPoolId: identityPool.ref,
+      roles: {
+        authenticated: authenticatedRole.roleArn,
+      },
+    });
+
     // 4. Implement API Gateway (REST API)
     const api = new apigateway.RestApi(this, 'KineticAtelierApi', {
       restApiName: 'KineticAtelierApi',
@@ -38,6 +111,12 @@ export class InfraStack extends cdk.Stack {
         allowMethods: apigateway.Cors.ALL_METHODS,
       },
     });
+
+    // Grant authenticated users permission to call the API
+    authenticatedRole.addToPolicy(new iam.PolicyStatement({
+      actions: ['execute-api:Invoke'],
+      resources: [api.arnForExecuteApi()],
+    }));
 
     // IAM Role for API Gateway to put events to EventBridge
     const apiEventBridgeRole = new iam.Role(this, 'ApiEventBridgeRole', {
@@ -83,6 +162,7 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // Vitals Endpoints
@@ -117,6 +197,7 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // GET /vitals -> DynamoDB Query
@@ -155,6 +236,7 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // GET /workouts -> DynamoDB Query
@@ -193,6 +275,53 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
+    });
+
+    // Profile Endpoints
+    const profile = api.root.addResource('profile');
+
+    // GET /profile -> DynamoDB GetItem
+    profile.addMethod('GET', new apigateway.AwsIntegration({
+      service: 'dynamodb',
+      action: 'GetItem',
+      options: {
+        credentialsRole: apiDynamoDBRole,
+        requestTemplates: {
+          'application/json': `{
+            "TableName": "${table.tableName}",
+            "Key": {
+              "PK": { "S": "USER#$context.identity.cognitoIdentityId" },
+              "SK": { "S": "PROFILE#$context.identity.cognitoIdentityId" }
+            }
+          }`,
+        },
+        integrationResponses: [
+          {
+            statusCode: '200',
+            responseTemplates: {
+              'application/json': `#set($item = $input.path('$.Item'))
+              {
+                "userId": "$item.PK.S",
+                "name": "$item.name.S",
+                "goals": {
+                  "weight": $item.goals.M.weight.N,
+                  "dailyCalories": $item.goals.M.dailyCalories.N,
+                  "macros": {
+                    "p": $item.goals.M.macros.M.p.N,
+                    "c": $item.goals.M.macros.M.c.N,
+                    "f": $item.goals.M.macros.M.f.N
+                  }
+                },
+                "isPro": $item.isPro.BOOL
+              }`,
+            },
+          },
+        ],
+      },
+    }), {
+      methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // Routine Endpoints
@@ -225,6 +354,7 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // GET /routines -> DynamoDB Query
@@ -263,6 +393,7 @@ export class InfraStack extends cdk.Stack {
       },
     }), {
       methodResponses: [{ statusCode: '200' }],
+      authorizationType: apigateway.AuthorizationType.IAM,
     });
 
     // 7. Implement Lambda Functions and Event Rules

--- a/infra/test/infra.test.ts
+++ b/infra/test/infra.test.ts
@@ -59,7 +59,7 @@ test('DynamoDB Table Created with Correct Keys', () => {
       { AttributeName: 'SK', AttributeType: 'S' }
     ],
     BillingMode: 'PAY_PER_REQUEST',
-    TableName: 'KineticAtelierTable'
+    TableName: Match.stringLikeRegexp('KineticAtelierTable-.*')
   });
 });
 

--- a/infra/test/infra.test.ts
+++ b/infra/test/infra.test.ts
@@ -2,6 +2,48 @@ import * as cdk from 'aws-cdk-lib';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import * as Infra from '../lib/infra-stack';
 
+test('Cognito User Pool and Client Created', () => {
+  const app = new cdk.App();
+  const stack = new Infra.InfraStack(app, 'MyTestStack');
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::Cognito::UserPool', {
+    UserPoolName: 'KineticAtelierUserPool',
+    AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+    AutoVerifiedAttributes: ['email'],
+    Schema: Match.arrayWith([
+      Match.objectLike({ Name: 'email', Required: true })
+    ])
+  });
+
+  template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+    SupportedIdentityProviders: ['COGNITO', 'Google'],
+    AllowedOAuthFlows: ['code']
+  });
+});
+
+test('Cognito Identity Pool and IAM Roles Created', () => {
+  const app = new cdk.App();
+  const stack = new Infra.InfraStack(app, 'MyTestStack');
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::Cognito::IdentityPool', {
+    AllowUnauthenticatedIdentities: false
+  });
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    AssumeRolePolicyDocument: {
+      Statement: [
+        {
+          Action: 'sts:AssumeRoleWithWebIdentity',
+          Effect: 'Allow',
+          Principal: { Federated: 'cognito-identity.amazonaws.com' }
+        }
+      ]
+    }
+  });
+});
+
 test('DynamoDB Table Created with Correct Keys', () => {
   const app = new cdk.App();
   const stack = new Infra.InfraStack(app, 'MyTestStack');
@@ -85,6 +127,7 @@ test('API Gateway Created with Routine Endpoints', () => {
   // Check POST /routines
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApiroutines.*') },
     Integration: {
       Type: 'AWS',
@@ -96,6 +139,7 @@ test('API Gateway Created with Routine Endpoints', () => {
   // Check GET /routines
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApiroutines.*') },
     Integration: {
       Type: 'AWS',
@@ -131,6 +175,7 @@ test('API Gateway Created with Workout Endpoints', () => {
   // Check POST /workouts
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApiworkouts.*') },
     Integration: {
       Type: 'AWS',
@@ -142,6 +187,7 @@ test('API Gateway Created with Workout Endpoints', () => {
   // Check GET /workouts
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApiworkouts.*') },
     Integration: {
       Type: 'AWS',
@@ -163,6 +209,7 @@ test('API Gateway Created with Vitals Endpoints', () => {
   // Check POST /vitals
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'POST',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApivitals.*') },
     Integration: {
       Type: 'AWS',
@@ -174,11 +221,33 @@ test('API Gateway Created with Vitals Endpoints', () => {
   // Check GET /vitals
   template.hasResourceProperties('AWS::ApiGateway::Method', {
     HttpMethod: 'GET',
+    AuthorizationType: 'AWS_IAM',
     ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApivitals.*') },
     Integration: {
       Type: 'AWS',
       IntegrationHttpMethod: 'POST',
       Uri: { 'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, ':apigateway:', { Ref: 'AWS::Region' }, ':dynamodb:action/Query']] }
+    }
+  });
+});
+
+test('API Gateway Created with Profile Endpoint', () => {
+  const app = new cdk.App();
+  const stack = new Infra.InfraStack(app, 'MyTestStack');
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::ApiGateway::Resource', {
+    PathPart: 'profile'
+  });
+
+  template.hasResourceProperties('AWS::ApiGateway::Method', {
+    HttpMethod: 'GET',
+    AuthorizationType: 'AWS_IAM',
+    ResourceId: { Ref: Match.stringLikeRegexp('KineticAtelierApiprofile.*') },
+    Integration: {
+      Type: 'AWS',
+      IntegrationHttpMethod: 'POST',
+      Uri: { 'Fn::Join': ['', ['arn:', { Ref: 'AWS::Partition' }, ':apigateway:', { Ref: 'AWS::Region' }, ':dynamodb:action/GetItem']] }
     }
   });
 });


### PR DESCRIPTION
This submission implements a native AWS authentication layer using Cognito User Pool and Identity Pool, as requested. It also defines a unified API specification for both Web and SwiftUI platforms, updates the infrastructure to use IAM authorization (SigV4), and adds a new `/profile` endpoint with direct DynamoDB integration. Documentation and infrastructure tests have been updated accordingly. All tests (CDK unit tests and Playwright E2E tests) passed successfully.

Fixes #12

---
*PR created automatically by Jules for task [4848462080167878708](https://jules.google.com/task/4848462080167878708) started by @sholtomaud*